### PR TITLE
Update CI to use burnoo's Maven

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,10 +4,8 @@ on:
   workflow_dispatch:
 
 env:
-  ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
-  ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
-  ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
-  ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
+  ORG_GRADLE_PROJECT_azureUsername: ${{ vars.AZURE_USERNAME }}
+  ORG_GRADLE_PROJECT_azureKey: ${{ secrets.AZURE_KEY }}
 
 jobs:
   deploy-linux:
@@ -24,7 +22,7 @@ jobs:
 
       - name: Linux deploy
         run: |
-          ./gradlew publish --no-daemon --stacktrace
+          ./gradlew publishAllPublicationsToBurnooRepository --no-daemon --stacktrace
 
   deploy-macos:
     runs-on: macos-latest
@@ -41,19 +39,19 @@ jobs:
       - name: Mac deploy
         run: |
           ./gradlew \
-          publishIosArm64PublicationToMavenRepository \
-          publishIosSimulatorArm64PublicationToMavenRepository \
-          publishIosX64PublicationToMavenRepository \
-          publishMacosX64PublicationToMavenRepository \
-          publishMacosArm64PublicationToMavenRepository \
-          publishWatchosArm32PublicationToMavenRepository \
-          publishWatchosArm64PublicationToMavenRepository \
-          publishWatchosDeviceArm64PublicationToMavenRepository \
-          publishWatchosSimulatorArm64PublicationToMavenRepository \
-          publishWatchosX64PublicationToMavenRepository \
-          publishTvosArm64PublicationToMavenRepository \
-          publishTvosSimulatorArm64PublicationToMavenRepository \
-          publishTvosX64PublicationToMavenRepository \
+          publishIosArm64PublicationToBurnooRepository \
+          publishIosSimulatorArm64PublicationToBurnooRepository \
+          publishIosX64PublicationToBurnooRepository \
+          publishMacosX64PublicationToBurnooRepository \
+          publishMacosArm64PublicationToBurnooRepository \
+          publishWatchosArm32PublicationToBurnooRepository \
+          publishWatchosArm64PublicationToBurnooRepository \
+          publishWatchosDeviceArm64PublicationToBurnooRepository \
+          publishWatchosSimulatorArm64PublicationToBurnooRepository \
+          publishWatchosX64PublicationToBurnooRepository \
+          publishTvosArm64PublicationToBurnooRepository \
+          publishTvosSimulatorArm64PublicationToBurnooRepository \
+          publishTvosX64PublicationToBurnooRepository \
           --no-daemon --stacktrace
 
   deploy-windows:
@@ -70,4 +68,4 @@ jobs:
 
       - name: Windows deploy
         run: |
-          ./gradlew publishMingwX64PublicationToMavenRepository --no-daemon --stacktrace
+          ./gradlew publishMingwX64PublicationToBurnooRepository --no-daemon --stacktrace

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,19 +53,3 @@ jobs:
           publishTvosSimulatorArm64PublicationToBurnooRepository \
           publishTvosX64PublicationToBurnooRepository \
           --no-daemon --stacktrace
-
-  deploy-windows:
-    runs-on: windows-latest
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: JDK setup
-        uses: actions/setup-java@v3
-        with:
-          java-version: 17
-          distribution: corretto
-
-      - name: Windows deploy
-        run: |
-          ./gradlew publishMingwX64PublicationToBurnooRepository --no-daemon --stacktrace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog #
 
+## v1.2.0-beap1 *(2023-06-27)* ##
+- Changes to publish 1.2.0 on burnoo's Maven
+
 ## v1.2.0 *(2023-04-XX)* ##
 
 - Update to Kotlin 1.9.23, Gradle 8.7, and Android Gradle Plugin 8.3.2

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,3 +42,21 @@ rootProject.extensions.findByType<NodeJsRootExtension>()?.apply {
 tasks.withType<KotlinNpmInstallTask>().configureEach {
     args.add("--ignore-engines")
 }
+
+// Adds burnoo's maven to all subprojects
+subprojects {
+    afterEvaluate {
+        this.extensions.findByType<PublishingExtension>()?.apply {
+            repositories {
+                maven {
+                    name = "burnoo"
+                    url = uri("https://pkgs.dev.azure.com/burnoo/maven/_packaging/public/maven/v1")
+                    credentials {
+                        username = rootProject.findProperty("azureUsername")?.toString()
+                        password = rootProject.findProperty("azureKey")?.toString()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,7 @@ tasks.withType<KotlinNpmInstallTask>().configureEach {
     args.add("--ignore-engines")
 }
 
-// Adds burnoo's maven to all subprojects
+// Adds burnoo's maven to all subprojects and disable artifact signing
 subprojects {
     afterEvaluate {
         this.extensions.findByType<PublishingExtension>()?.apply {
@@ -58,5 +58,7 @@ subprojects {
                 }
             }
         }
+
+        this.tasks.withType<Sign>().configureEach { enabled = false }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-multiplatformSettings = "1.2.0"
+multiplatformSettings = "1.2.0-beap1"
 
 kotlin = "1.9.24"
 

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -25,7 +25,7 @@ plugins {
 }
 
 allprojects {
-    ext["library_version"] = "1.2.0"
+    ext["library_version"] = "1.2.0-beap1"
 
     repositories {
         mavenLocal()


### PR DESCRIPTION
Update CI to use burnoo's maven ([GitHub repository](https://github.com/burnoo/maven), [Azure Maven Feed](https://dev.azure.com/burnoo/maven/_artifacts/feed/public))

Changes:
- [Add burnoo's Maven to all subprojects](https://github.com/burnoo/multiplatform-settings/commit/a8ad0df74cb8ae8de889d5d4e929ff0d54e38306)
- [Disable signing for publishing artifacts](https://github.com/burnoo/multiplatform-settings/commit/15aaaa5c9166b4d37c9b1c5f0fd6868b66cfe637)
- [Change deploy GitHub action to use burnoo's Maven](https://github.com/burnoo/multiplatform-settings/commit/9b5e6621a311f32c96b8b47c350371c81e4f0c15)
- [Remove Windows deploy job as Linux job is deploying MingwX64 already](https://github.com/burnoo/multiplatform-settings/commit/a95ec2d99b9735aec0efbbbecfeb9c93891470d1)
- [Bump library version to 1.2.0-beap1](https://github.com/burnoo/multiplatform-settings/commit/37d615b14fc553caafcc85a5e60fa84805ae84f5)